### PR TITLE
fix(secret): add file type support

### DIFF
--- a/pkg/model/secret.go
+++ b/pkg/model/secret.go
@@ -1,33 +1,157 @@
 package model
 
-import "strings"
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type SecretType string
+
+const (
+	SecretTypeEnv  SecretType = "env"
+	SecretTypeFile SecretType = "file"
+)
 
 type (
 	SecretResponse struct {
-		Secrets map[string]Secret `json:"secrets"`
+		EnvSecrets  map[string]EnvSecret  `json:"envSecrets"`
+		FileSecrets map[string]FileSecret `json:"fileSecrets"`
 	}
 
-	Secret struct {
-		Id string `json:"id"`
-		Key string `json:"key"`
+	EnvSecret struct {
+		Id    string `json:"id"`
+		Key   string `json:"key"`
 		Value string `json:"value"`
+	}
+
+	FileSecret struct {
+		Id       string `json:"id"`
+		Filename string `json:"filename"`
+		Value    string `json:"value"`
+		Mode     string `json:"mode"`
+	}
+
+	SecretMetadata struct {
+		Type     SecretType
+		Filename string
 	}
 )
 
-func NewSecret(id, value string) Secret {
+// ParseSecretMetadata extracts secret metadata from GCP secret labels.
+// Secrets without a "type" label default to "env" type for backward compatibility.
+func ParseSecretMetadata(labels map[string]string) SecretMetadata {
+	secretType := SecretTypeEnv
+	if t, ok := labels["type"]; ok && t == "file" {
+		secretType = SecretTypeFile
+	}
+
+	filename := ""
+	if f, ok := labels["filename"]; ok {
+		filename = f
+	}
+
+	return SecretMetadata{
+		Type:     secretType,
+		Filename: filename,
+	}
+}
+
+// DetermineFileMode returns the appropriate file mode based on filename patterns.
+// Private keys get 0600, certificates get 0644, default is 0600 for security.
+func DetermineFileMode(filename string) string {
+	lower := strings.ToLower(filename)
+	base := strings.ToLower(filepath.Base(filename))
+
+	// Private keys - owner only
+	if strings.HasSuffix(lower, ".key") ||
+		strings.HasSuffix(lower, ".pem") ||
+		strings.Contains(base, "private") {
+		return "0600"
+	}
+
+	// Certificates - world readable
+	if strings.HasSuffix(lower, ".crt") ||
+		strings.HasSuffix(lower, ".cert") ||
+		strings.HasSuffix(lower, ".ca") {
+		return "0644"
+	}
+
+	// Secure default
+	return "0600"
+}
+
+// NewEnvSecret creates a new EnvSecret from an id and value.
+// The key is extracted from the last part of the id (e.g., "projects/123/secrets/DB_URL" -> "DB_URL").
+func NewEnvSecret(id, value string) EnvSecret {
 	parts := strings.Split(id, "/")
 	key := parts[len(parts)-1]
-	return Secret{
-		Id: id,
-		Key: key,
+	return EnvSecret{
+		Id:    id,
+		Key:   key,
 		Value: value,
 	}
 }
 
-func NewSecretResponse(secrets map[string]string) SecretResponse {
-	secretMap := make(map[string]Secret)
-	for id, value := range secrets {
-		secretMap[id] = NewSecret(id, value)
+// NewFileSecret creates a new FileSecret with the specified parameters.
+func NewFileSecret(id, value, filename, mode string) FileSecret {
+	return FileSecret{
+		Id:       id,
+		Filename: filename,
+		Value:    value,
+		Mode:     mode,
 	}
-	return SecretResponse{Secrets: secretMap}
+}
+
+// NewSecretResponse creates a SecretResponse from env and file secret maps.
+func NewSecretResponse(envSecrets map[string]EnvSecret, fileSecrets map[string]FileSecret) SecretResponse {
+	if envSecrets == nil {
+		envSecrets = make(map[string]EnvSecret)
+	}
+	if fileSecrets == nil {
+		fileSecrets = make(map[string]FileSecret)
+	}
+	return SecretResponse{
+		EnvSecrets:  envSecrets,
+		FileSecrets: fileSecrets,
+	}
+}
+
+// ValidateFilename validates that a filename is safe for use as a secret file path.
+// It only allows a single directory level (e.g., "file.txt" or "certs/tls.crt").
+// Returns an error for absolute paths, path traversal attempts, or deeply nested paths.
+func ValidateFilename(filename string) error {
+	if filename == "" {
+		return fmt.Errorf("filename cannot be empty")
+	}
+
+	// Reject absolute paths
+	if filepath.IsAbs(filename) {
+		return fmt.Errorf("absolute paths are not allowed")
+	}
+
+	// Clean and resolve the path
+	cleaned := filepath.Clean(filename)
+
+	// Check if the cleaned path escapes the current directory
+	// by computing relative path from a base directory
+	baseDir := "/safe"
+	fullPath := filepath.Join(baseDir, cleaned)
+	rel, err := filepath.Rel(baseDir, fullPath)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	// If relative path starts with "..", it escapes the base directory
+	if rel != cleaned || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("path traversal not allowed")
+	}
+
+	// Count directory depth - only allow one level (dir/file)
+	depth := strings.Count(cleaned, string(filepath.Separator))
+	if depth > 1 {
+		return fmt.Errorf("only one directory level allowed (e.g., 'certs/tls.crt')")
+	}
+
+	return nil
 }

--- a/pkg/model/secret_test.go
+++ b/pkg/model/secret_test.go
@@ -6,23 +6,192 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewSecret(t *testing.T) {
+func TestParseSecretMetadata(t *testing.T) {
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		expectedType   SecretType
+		expectedFile   string
+	}{
+		{
+			name:           "empty labels defaults to env",
+			labels:         map[string]string{},
+			expectedType:   SecretTypeEnv,
+			expectedFile:   "",
+		},
+		{
+			name:           "nil labels defaults to env",
+			labels:         nil,
+			expectedType:   SecretTypeEnv,
+			expectedFile:   "",
+		},
+		{
+			name:           "explicit env type",
+			labels:         map[string]string{"type": "env"},
+			expectedType:   SecretTypeEnv,
+			expectedFile:   "",
+		},
+		{
+			name:           "file type with filename",
+			labels:         map[string]string{"type": "file", "filename": "certs/tls.crt"},
+			expectedType:   SecretTypeFile,
+			expectedFile:   "certs/tls.crt",
+		},
+		{
+			name:           "file type without filename",
+			labels:         map[string]string{"type": "file"},
+			expectedType:   SecretTypeFile,
+			expectedFile:   "",
+		},
+		{
+			name:           "unknown type defaults to env",
+			labels:         map[string]string{"type": "unknown"},
+			expectedType:   SecretTypeEnv,
+			expectedFile:   "",
+		},
+		{
+			name:           "service label only (backward compat)",
+			labels:         map[string]string{"service": "my-service"},
+			expectedType:   SecretTypeEnv,
+			expectedFile:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := ParseSecretMetadata(tt.labels)
+			assert.Equal(t, tt.expectedType, metadata.Type)
+			assert.Equal(t, tt.expectedFile, metadata.Filename)
+		})
+	}
+}
+
+func TestDetermineFileMode(t *testing.T) {
+	tests := []struct {
+		filename     string
+		expectedMode string
+	}{
+		// Private keys - 0600
+		{"tls.key", "0600"},
+		{"server.key", "0600"},
+		{"certs/tls.key", "0600"},
+		{"private.pem", "0600"},
+		{"server.pem", "0600"},
+		{"private-key.txt", "0600"},
+		{"my-private-cert", "0600"},
+
+		// Certificates - 0644
+		{"tls.crt", "0644"},
+		{"server.crt", "0644"},
+		{"certs/tls.crt", "0644"},
+		{"ca.cert", "0644"},
+		{"root.ca", "0644"},
+
+		// Default - 0600 (secure default)
+		{"config.json", "0600"},
+		{"data.txt", "0600"},
+		{"unknown", "0600"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			mode := DetermineFileMode(tt.filename)
+			assert.Equal(t, tt.expectedMode, mode)
+		})
+	}
+}
+
+func TestNewEnvSecret(t *testing.T) {
 	id := "projects/111111111/secrets/SECRETS_NAME"
 	value := "top secret"
 
-	secret := NewSecret(id, value)
+	secret := NewEnvSecret(id, value)
 	assert.Equal(t, id, secret.Id)
 	assert.Equal(t, value, secret.Value)
 	assert.Equal(t, "SECRETS_NAME", secret.Key)
 }
 
+func TestNewFileSecret(t *testing.T) {
+	id := "projects/111111111/secrets/tls-cert"
+	value := "-----BEGIN CERTIFICATE-----"
+	filename := "certs/tls.crt"
+	mode := "0644"
+
+	secret := NewFileSecret(id, value, filename, mode)
+	assert.Equal(t, id, secret.Id)
+	assert.Equal(t, value, secret.Value)
+	assert.Equal(t, filename, secret.Filename)
+	assert.Equal(t, mode, secret.Mode)
+}
+
 func TestNewSecretResponse(t *testing.T) {
-	secrets := map[string]string{
-		"projects/111111111/secrets/SECRETS_NAME": "top secret",
+	envSecrets := map[string]EnvSecret{
+		"projects/111111111/secrets/DB_URL": NewEnvSecret("projects/111111111/secrets/DB_URL", "postgres://localhost"),
+	}
+	fileSecrets := map[string]FileSecret{
+		"projects/111111111/secrets/tls-cert": NewFileSecret("projects/111111111/secrets/tls-cert", "cert-data", "certs/tls.crt", "0644"),
 	}
 
-	response := NewSecretResponse(secrets)
-	assert.Equal(t, 1, len(response.Secrets))
-	assert.Equal(t, "top secret", response.Secrets["projects/111111111/secrets/SECRETS_NAME"].Value)
-	assert.Equal(t, "SECRETS_NAME", response.Secrets["projects/111111111/secrets/SECRETS_NAME"].Key)
+	response := NewSecretResponse(envSecrets, fileSecrets)
+
+	assert.Equal(t, 1, len(response.EnvSecrets))
+	assert.Equal(t, "postgres://localhost", response.EnvSecrets["projects/111111111/secrets/DB_URL"].Value)
+	assert.Equal(t, "DB_URL", response.EnvSecrets["projects/111111111/secrets/DB_URL"].Key)
+
+	assert.Equal(t, 1, len(response.FileSecrets))
+	assert.Equal(t, "cert-data", response.FileSecrets["projects/111111111/secrets/tls-cert"].Value)
+	assert.Equal(t, "certs/tls.crt", response.FileSecrets["projects/111111111/secrets/tls-cert"].Filename)
+}
+
+func TestNewSecretResponseWithNilMaps(t *testing.T) {
+	response := NewSecretResponse(nil, nil)
+
+	assert.NotNil(t, response.EnvSecrets)
+	assert.NotNil(t, response.FileSecrets)
+	assert.Equal(t, 0, len(response.EnvSecrets))
+	assert.Equal(t, 0, len(response.FileSecrets))
+}
+
+func TestValidateFilename(t *testing.T) {
+	tests := []struct {
+		name      string
+		filename  string
+		wantError bool
+	}{
+		// Valid cases
+		{"simple filename", "tls.crt", false},
+		{"single dir level", "certs/tls.crt", false},
+		{"single dir level key", "certs/tls.key", false},
+		{"config file", "config.json", false},
+
+		// Invalid: empty
+		{"empty filename", "", true},
+
+		// Invalid: absolute paths
+		{"absolute path unix", "/etc/passwd", true},
+		{"absolute path with file", "/certs/tls.crt", true},
+
+		// Invalid: path traversal
+		{"parent directory", "..", true},
+		{"parent with file", "../passwd", true},
+		{"parent in middle", "certs/../../../etc/passwd", true},
+		{"double parent", "../../etc/passwd", true},
+		{"hidden parent traversal", "certs/../../etc/passwd", true},
+
+		// Invalid: too many directory levels
+		{"two dir levels", "a/b/c.txt", true},
+		{"three dir levels", "a/b/c/d.txt", true},
+		{"deep nesting", "var/log/app/secrets/tls.crt", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFilename(tt.filename)
+			if tt.wantError {
+				assert.Error(t, err, "expected error for filename: %s", tt.filename)
+			} else {
+				assert.NoError(t, err, "unexpected error for filename: %s", tt.filename)
+			}
+		})
+	}
 }


### PR DESCRIPTION
WHen the file type is set on secret label like type:file and label fileane:t.txt then the server response this metadata and the client will handle it by writing normal secert into the passed output file and the secrets of type file to the configured filename from the labels.