### PR TITLE
feat(auth): add API key authentication

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/containifyci/secret-operator/internal"
+	"github.com/containifyci/secret-operator/pkg/auth"
 	"github.com/containifyci/secret-operator/pkg/model"
 	"github.com/containifyci/secret-operator/pkg/token"
 
@@ -57,14 +58,22 @@ func main() {
 }
 
 func start() {
+	ctx := context.Background()
+	projectID := os.Getenv("GCP_PROJECT_ID")
+
+	apiKey, err := auth.LoadAPIKey(ctx, projectID)
+	if err != nil {
+		log.Fatalf("Failed to load API key: %v", err)
+	}
+
 	http.HandleFunc("/retrieve-secrets", RetrieveSecretsHandler)
-	http.HandleFunc("/generate-token", GenerateTokenHandler)
+	http.HandleFunc("/generate-token", auth.RequireBearerAuth(apiKey, GenerateTokenHandler))
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
 	log.Printf("Starting server on port %s", port)
-	err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	err = http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("Failed to start server: %v", err)
 	}

--- a/internal/const.go
+++ b/internal/const.go
@@ -1,3 +1,4 @@
 package internal
 
 var AuthenticationTokenName = "SECRET_OPERATOR_AUTHENTICATION_TOKEN" // Replace with the desired token secret name
+var APIKeySecretName = "SECRET_OPERATOR_API_KEY"

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+
+	"github.com/containifyci/secret-operator/internal"
+)
+
+// LoadAPIKey fetches the API key from GCP Secret Manager.
+func LoadAPIKey(ctx context.Context, projectID string) (string, error) {
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Secret Manager client: %w", err)
+	}
+	defer client.Close()
+
+	name := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", projectID, internal.APIKeySecretName)
+	resp, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+		Name: name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to access API key secret: %w", err)
+	}
+
+	key := strings.TrimSpace(string(resp.Payload.Data))
+	if key == "" {
+		return "", fmt.Errorf("API key secret is empty")
+	}
+
+	return key, nil
+}
+
+// RequireBearerAuth wraps an http.HandlerFunc with Bearer token authentication.
+func RequireBearerAuth(apiKey string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			unauthorized(w, r)
+			return
+		}
+
+		token := authHeader[len("Bearer "):]
+		if len(token) == 0 || subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) != 1 {
+			unauthorized(w, r)
+			return
+		}
+
+		next(w, r)
+	}
+}
+
+func unauthorized(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Unauthorized request to %s from %s", r.URL.Path, r.RemoteAddr)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func okHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestRequireBearerAuth_ValidKey(t *testing.T) {
+	handler := RequireBearerAuth("test-api-key", okHandler)
+	req := httptest.NewRequest(http.MethodPost, "/generate-token", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRequireBearerAuth_InvalidKey(t *testing.T) {
+	handler := RequireBearerAuth("test-api-key", okHandler)
+	req := httptest.NewRequest(http.MethodPost, "/generate-token", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "unauthorized")
+}
+
+func TestRequireBearerAuth_MissingHeader(t *testing.T) {
+	handler := RequireBearerAuth("test-api-key", okHandler)
+	req := httptest.NewRequest(http.MethodPost, "/generate-token", nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireBearerAuth_MalformedHeader(t *testing.T) {
+	handler := RequireBearerAuth("test-api-key", okHandler)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"Basic auth", "Basic dGVzdDp0ZXN0"},
+		{"bare token", "test-api-key"},
+		{"lowercase bearer", "bearer test-api-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/generate-token", nil)
+			req.Header.Set("Authorization", tt.value)
+			rec := httptest.NewRecorder()
+
+			handler(rec, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		})
+	}
+}
+
+func TestRequireBearerAuth_EmptyToken(t *testing.T) {
+	handler := RequireBearerAuth("test-api-key", okHandler)
+	req := httptest.NewRequest(http.MethodPost, "/generate-token", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}


### PR DESCRIPTION
- Add API key retrieval function from GCP Secret Manager
- Implement Bearer token authentication middleware
- Update server to use the new authentication mechanism